### PR TITLE
Removed requirement for Python3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ packages = [{ include = "poetry_dotenv", from = "src" }]
 "Say Thanks!" = "https://www.buymeacoffee.com/volopivoshenko"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8"
 poetry = "^1.3.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Removed upper bounding requirement for <Py3.11.

All tests pass. 100% code coverage.

# Pull Request Check List

**Resolves: #24**

