### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,11 @@
 version: 2
 
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: pip
     directory: "/"
     schedule:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,7 +6,7 @@ name: CD
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   release:
@@ -18,13 +18,13 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout-repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Python
         id: install-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           architecture: x64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   linters:
@@ -16,13 +16,13 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout-repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Python
         id: install-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           architecture: x64
@@ -44,19 +44,19 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout repository
         id: checkout-repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Python
         id: install-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout-repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         id: initialize-codeql

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout-repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Dependency review
         id: dependency-review
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v3


### PR DESCRIPTION
Hi @volopivoshenko,
I'm using this great plugin since a while. Today I noticed that the GitHub Actions used in the CI workflows are **outdated**.

So I upgraded those and also added a new entry in the Dependabot config file to ease future upgrades.

Regards,
Adrian
